### PR TITLE
added comment explaining how to add non-scrolling images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ A Simple parallax-scrolling library for pyGame.
 
 It's simple, and I mean really simple. It lets you add a series of surfaces and scroll them at different speeds on top of each other. This gives a simple parallax effect that give a sense of depth.
 
+If you'd like to add an image that does not scroll at all, set the `scroll_factor` for the image to `math.inf` when calling `ParallaxSurface.add()`. Due to how Python treats `math.inf`, an image with this `scroll_factor` will never scroll.
 
 Contributors:
 -------------
 zero-clouds
 ghighi-du63000
 williamu32
+cheffley6

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you'd like to add an image that does not scroll at all, set the `scroll_facto
 
 Contributors:
 -------------
-zero-clouds
-ghighi-du63000
-williamu32
-cheffley6
+zero-clouds  
+ghighi-du63000  
+williamu32  
+cheffley6  


### PR DESCRIPTION
#### Description
This change explains to the user how to add an image that doesn't scroll at all. I was initially thinking that Python uses a very large number to represent `math.inf`, similarly to how Java has an `Integer.MAX_VALUE`, but it in fact is logically consistent with how infinity should actually be treated. Thus, we can set `scroll_factor` to `math.inf` in order to ensure that an image will NEVER scroll given any amount of time.

It took me a bit of time to reach this conclusion, and I suspect there might be others in the future that'll have the same thought process. I think that adding a note in the documentation will help anyone who has the same issue.

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [x] Documentation improvements
- [ ] Test improvements

#### Testing
No testing is needed, only the README is changed.

#### Documentation
This change adds documentation for how to add an image that shouldn't move.


